### PR TITLE
Speed up regex matching

### DIFF
--- a/quotequail/_internal.py
+++ b/quotequail/_internal.py
@@ -22,7 +22,7 @@ def find_pattern_on_line(lines, n, max_wrap_lines):
                 match_line = ''.join(lines[n:n+1+m])
                 if match_line.startswith('>'):
                     match_line = match_line[1:].strip()
-                if re.match(regex, match_line.strip()):
+                if regex.match(match_line.strip()):
                     return n+m, typ
     return None, None
 


### PR DESCRIPTION
Python doesn't complain if you pass a regex object into `re.match` but there appears to be a speed difference:

```
In [1]: import re

In [2]: r = re.compile('x')

In [3]: %timeit re.match(r, 'x')
The slowest run took 7.74 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 2.34 µs per loop

In [4]: %timeit r.match('x')
The slowest run took 10.88 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 351 ns per loop
```