### PR TITLE
Fix auto-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build_and_upload:
-    runs-on: arc-amd64-runners
+    runs-on: 'ubuntu-20.04'
     environment: production
     permissions:
       # id-token for the trusted publisher setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,5 +81,3 @@ jobs:
           python setup.py sdist
       - name: Upload to PyPI
         uses: closeio/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # v1.9
-        with:
-          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,3 +79,5 @@ jobs:
           python setup.py sdist
       - name: Upload to PyPI
         uses: closeio/gh-action-pypi-publish@a260c7e54e4251db69485e1e7ca271aec8c0ddf9
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     permissions:
       # id-token for the trusted publisher setup
       id-token: write
+      # for tagging the commit
+      contents: write
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,4 +82,4 @@ jobs:
       - name: Upload to PyPI
         uses: closeio/gh-action-pypi-publish@a260c7e54e4251db69485e1e7ca271aec8c0ddf9
         with:
-          repository-url: https://test.pypi.org/legacy/
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,6 @@ jobs:
         run: |
           python setup.py sdist
       - name: Upload to PyPI
-        uses: closeio/gh-action-pypi-publish@a260c7e54e4251db69485e1e7ca271aec8c0ddf9
+        uses: closeio/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # v1.9
         with:
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
   build_and_upload:
     runs-on: arc-amd64-runners
     environment: production
+    permissions:
+      # id-token for the trusted publisher setup
+      id-token: write
     steps:
       - uses: actions/checkout@v2
 
@@ -76,6 +79,3 @@ jobs:
           python setup.py sdist
       - name: Upload to PyPI
         uses: closeio/gh-action-pypi-publish@a260c7e54e4251db69485e1e7ca271aec8c0ddf9
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
I've tested on TestPypi and set up a trusted publisher on real Pypi so we don't need any secrets attached to this repo.

Once this merges we should be able to create releases off of master using the action.

Example run: https://github.com/closeio/quotequail/actions/runs/9651569176/job/26619748454

I've also deleted the tags created during testing.