### PR TITLE
Handle `@` in tag names from lxml >= 6.0 HTML parser

### DIFF
--- a/quotequail/_html.py
+++ b/quotequail/_html.py
@@ -229,10 +229,14 @@ def get_html_tree(html: str) -> Element:
     # HACK for Outlook emails, where tags like <o:p> are rendered as <p>. We
     # can generally ignore these tags so we replace them with <span>, which
     # doesn't cause a line break. Also, we can't look up the element path of
-    # tags that contain colons. When rendering the tree, we will restore the
-    # tag name.
+    # tags that contain characters which aren't valid in an XPath NameTest
+    # (e.g. ``:`` in ``<o:p>``, or ``@`` in pseudo-tags like
+    # ``<addr@domain>`` that lxml >= 6.0's HTML parser keeps from quoted
+    # reply headers). When rendering the tree, we will restore the tag name.
     for el in tree.iter():
-        if el.nsmap or (isinstance(el.tag, str) and ":" in el.tag):
+        if el.nsmap or (
+            isinstance(el.tag, str) and (":" in el.tag or "@" in el.tag)
+        ):
             if el.nsmap:
                 actual_tag_name = f"{next(iter(el.nsmap.keys()))}:{el.tag}"
             else:

--- a/tests/test_unwrap_html.py
+++ b/tests/test_unwrap_html.py
@@ -105,6 +105,35 @@ def test_thunderbird_forward(read_file):
     assert "html_bottom" not in result
 
 
+def test_unwrap_html_with_email_address_pseudo_tag():
+    # Some quoted-reply headers contain bare ``Name <addr@domain>`` text. With
+    # lxml >= 6.0 the HTML parser keeps ``<addr@domain>`` as an element with a
+    # tag name containing ``@``. ``getelementpath()`` then emits that raw name
+    # as a path component, which the elementpath tokenizer used by ``find()``
+    # rejects (``@`` is the attribute axis token), raising ``KeyError: '@'``.
+    # ``unwrap_html`` should be resilient to that.
+    html = (
+        "Hey Jane,<br><br>Some reply text.<br>Dan"
+        '<div><span data-system-generated="meta">'
+        "On Sep 04, 2025, 11:30 AM, "
+        "Jane Roe <jane@example.com> wrote:<br>"
+        "</span></div>"
+        "<blockquote>Original message body</blockquote>"
+    )
+
+    # The important guarantee is that ``unwrap_html`` doesn't crash and
+    # returns sensible top/quoted content. The detected ``type`` differs
+    # slightly between lxml versions (lxml 5 strips the bogus ``<jane@...>``
+    # tag at parse time, lxml 6 keeps it; we then coerce it to ``<span>``),
+    # so we don't pin the exact value.
+    result = unwrap_html(html)
+
+    assert result is not None
+    assert result["type"] in {"quote", "reply"}
+    assert "Some reply text" in result["html_top"]
+    assert "Original message body" in result["html"]
+
+
 def test_mailru_forward(read_file):
     data = read_file("mailru_forward.html")
     result = unwrap_html(data)


### PR DESCRIPTION
Updated to lxml >6.0 in closeio due to a security vuln and it caused this:
https://closeio.sentry.io/issues/7461358574/?project=4506066590433280

Extend the existing :-in-tag-name HACK in get_html_tree to also rewrite tags containing @ to <span>, stashing the original name in __tag_name so render_html_tree can restore it.

Ships a test to verify the case linked above.