### PR TITLE
Bump `gh-action-pypi-publish` to support `Metadata-Version: 2.4`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,4 +80,4 @@ jobs:
         run: |
           python setup.py sdist
       - name: Upload to PyPI
-        uses: closeio/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # v1.9
+        uses: closeio/gh-action-pypi-publish@4e1cbcbad1239984423d90356ff89704f88627db  # unstable/v1, pypa v1.13.0 equivalent


### PR DESCRIPTION
`ubuntu-latest` now has `setuptools` 77+, which produces `Metadata-Version: 2.4`. The old `twine` in our pinned action doesn't support that. Bumping the SHA pulls in a newer `twine` that does.