### PR TITLE
Switch to upstream pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,4 +80,4 @@ jobs:
         run: |
           python setup.py sdist
       - name: Upload to PyPI
-        uses: closeio/gh-action-pypi-publish@4e1cbcbad1239984423d90356ff89704f88627db  # unstable/v1, pypa v1.13.0 equivalent
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0


### PR DESCRIPTION
Follow-up to #70: newer versions of the action pull the container image from `ghcr.io/<repo>/gh-action-pypi-publish:<sha>` whenever invoked from a fork, and our `closeio` fork doesn't publish one → `denied` ([failed run](https://github.com/closeio/quotequail/actions/runs/26574253223)).

Since the fork has no `closeio`-specific patches, just point at upstream. Pinned to the `v1.13.0` SHA, same as `tasktiger` and `tz-trout`.