### PR TITLE
build and publish a wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.10"
 
       - run: |
-          pip install packaging
+          pip install build packaging
       - name: Normalize the release version
         run: |
           echo "release_version=`echo '${{ github.event.inputs.requested_release_tag }}' | sed 's/^v//'`" >> $GITHUB_ENV
@@ -76,8 +76,8 @@ jobs:
               ref: 'refs/tags/${{ env.release_tag }}',
               sha: context.sha
             })
-      - name: Build Source Distribution
+      - name: Build Distributions
         run: |
-          python setup.py sdist
+          python -m build
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0


### PR DESCRIPTION
build and publish a wheel, in addition to a source distribution.

Also direct invocation of setup.py is deprecated, so I switch to `build`