### PR TITLE
Fix KeyError when HTML contains tags with '=' in their name

### DIFF
--- a/quotequail/_html.py
+++ b/quotequail/_html.py
@@ -173,11 +173,13 @@ def slice_tree(
 
         if start_ref:
             selector = et.getelementpath(start_ref[0])
-            start_ref = (new_tree.find(selector), start_ref[1])
+            results = new_tree.xpath(selector)
+            start_ref = (results[0] if results else None, start_ref[1])
 
         if end_ref:
             selector = et.getelementpath(end_ref[0])
-            end_ref = (new_tree.find(selector), end_ref[1])
+            results = new_tree.xpath(selector)
+            end_ref = (results[0] if results else None, end_ref[1])
 
     else:
         new_tree = tree
@@ -246,8 +248,9 @@ def get_html_tree(html_str: str) -> Element:
             el.attrib["__tag_name"] = el.tag
             el.tag = "span"
 
-        elif "@" in el.tag:
-            # Mail client forgot to escape <addr@domain>. Flatten back to
+        elif "@" in el.tag or "=" in el.tag:
+            # Mail client forgot to escape <addr@domain> or used other
+            # XPath-special chars (like =) in tag names. Flatten back to
             # visible text so the address actually renders.
             attrs = "".join(
                 f' {k}="{html.escape(v, quote=True)}"'

--- a/tests/test_quote_html.py
+++ b/tests/test_quote_html.py
@@ -237,6 +237,34 @@ def test_prefix_tag_2():
     ]
 
 
+def test_tag_with_equals_sign():
+    # lxml parses unescaped constructs like <key=value> as a tag whose name
+    # contains '='. getelementpath then produces a path with '=' that lxml's
+    # ElementPath find() cannot parse (KeyError: '='). Verify that quote_html
+    # handles this without crashing and still correctly splits the quote.
+    assert quote_html(
+        "<html><body>"
+        "<div>Here is my reply.</div>"
+        "<div>On Jan 1, Joe <key=value> wrote:</div>"
+        "<blockquote>Original text here.</blockquote>"
+        "</body></html>"
+    ) == [
+        (
+            True,
+            "<html><body>"
+            "<div>Here is my reply.</div>"
+            "<div>On Jan 1, Joe &lt;key=value&gt; wrote:</div>"
+            "</body></html>",
+        ),
+        (
+            False,
+            "<html><body>"
+            "<blockquote>Original text here.</blockquote>"
+            "</body></html>",
+        ),
+    ]
+
+
 def test_encoding():
     # We assume everything is UTF-8
     assert quote_html("""<?xml version="1.0" encoding="ISO-8859-1"?>


### PR DESCRIPTION
lxml's HTML parser accepts malformed tags like <key=value> as elements whose tag name contains '='. getelementpath() then produces a path that lxml's ElementPath find() cannot parse, raising KeyError: '='.

Fix by extending the existing '@' sanitization in get_html_tree() to also drop elements with '=' in their tag name, and by switching slice_tree() from find() to xpath() as a secondary safety net.