### PR TITLE
Declare lxml as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ setup(
         "quotequail",
     ],
     test_suite="tests",
-    tests_require=["lxml"],
-    install_requires=["typing_extensions>=4.1"],
+    install_requires=["lxml>=6", "typing_extensions>=4.1"],
     platforms="any",
     classifiers=[
         "Environment :: Web Environment",


### PR DESCRIPTION
We use lxml unconditionally, so it should be listed as a required dependency.

We test on 6.1.1 but we shouldn't be too strict about the version of a dependency of a library. We do however declare >=6 as there are breaking changes in lxml 6.x. vs 5 and we won't support both versions moving forward.