### PR TITLE
Bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
       # for tagging the commit
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
         name: Install Python
         with:
           python-version: "3.10"
@@ -67,7 +67,7 @@ jobs:
           echo "release_version=$release_version" >> $GITHUB_OUTPUT
           echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
       - name: Tag commit
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.git.createRef({

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     container: python:${{ matrix.python-version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Lint code
         run: |
@@ -43,7 +43,7 @@ jobs:
     container: python:${{ matrix.python-version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
GitHub Actions runners switch their default Node runtime from Node 20 to
**Node 24 on June 16, 2026** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).
This bumps the actions that were pinned to Node 20–era versions so CI keeps
working after the switch.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v2` | `v6` |
| `actions/github-script` | `v7.0.1` | `v8` |
| `actions/setup-python` | `v2` | `v6` |

**Note:**
- `actions/github-script`: v9 has breaking changes — pin to v8

CI maintenance only — no application or runtime code changes.

Closes #76
