### PR TITLE
Release 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## v0.5.1
+
+* Fixes for lxml >=6 compatibility
+* Declare lxml as a dependency (#74)
+* Fix KeyError when HTML contains tags with '=' in their name
+
 ## v0.5.0
 
 * On lxml >= 6 only: unescaped `<addr@domain>` pseudo-tags (common in

--- a/quotequail/__init__.py
+++ b/quotequail/__init__.py
@@ -4,7 +4,7 @@
 from . import _internal, _patterns
 from ._enums import Position
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __all__ = ["quote", "quote_html", "unwrap", "unwrap_html"]
 
 


### PR DESCRIPTION
## v0.5.1

* Fixes for lxml >=6 compatibility
* Declare lxml as a dependency (#74)
* Fix KeyError when HTML contains tags with '=' in their name


Long time coming: https://github.com/closeio/quotequail/pull/75#issuecomment-4629696476