### PR TITLE
Fix quoted html being empty when the quote is only an image

### DIFF
--- a/quotequail/_html.py
+++ b/quotequail/_html.py
@@ -34,6 +34,8 @@ INLINE_TAGS = [
     "th",
 ]
 
+IMAGE_LINE_TEXT = "\ufffc"
+
 
 def trim_tree_after(element: Element, include_element: bool = True):
     """
@@ -389,6 +391,9 @@ def tree_line_generator(
     # Buffer for the current line.
     line = ""
 
+    # Whether the current line contains an image.
+    has_image = False
+
     # The reference tuple (element, position) for the start of the line.
     start_ref = None
 
@@ -416,6 +421,9 @@ def tree_line_generator(
             if is_block or line_break:
                 line = _trim_spaces(line)
 
+                if not line and has_image:
+                    line = IMAGE_LINE_TEXT
+
                 if line or line_break or is_forward:
                     end_ref = (el, state)
                     yield start_ref, end_ref, start_indentation_level, line
@@ -423,6 +431,7 @@ def tree_line_generator(
                     if max_lines is not None and counter > max_lines:
                         return
                     line = ""
+                    has_image = False
 
                     if is_forward:
                         # Simulate forward
@@ -439,6 +448,12 @@ def tree_line_generator(
                 if not line:
                     start_ref = (el, state)
                     start_indentation_level = indentation_level
+
+            # Flag the image after any pending line was flushed above, so that
+            # the image starts a line of its own (start_ref now points at it)
+            # and gets flushed at its end tag.
+            if tag_name == "img" and state is Position.Begin:
+                has_image = True
 
         elif isinstance(token, str):
             line += token

--- a/quotequail/_html.py
+++ b/quotequail/_html.py
@@ -34,6 +34,8 @@ INLINE_TAGS = [
     "th",
 ]
 
+# Unicode object replacement character. Arbitrary choice of character to
+# represent an image line.
 IMAGE_LINE_TEXT = "\ufffc"
 
 

--- a/tests/test_unwrap_html.py
+++ b/tests/test_unwrap_html.py
@@ -39,6 +39,24 @@ def test_unwrap_html_image_only_quoted_body():
     }
 
 
+def test_unwrap_html_image_at_start_of_quoted_body():
+    # An image at the start of the quoted message, followed by text, used to
+    # be dropped from the quote (closeio/quotequail#22).
+    html = (
+        "<p>Top text</p>"
+        "<p>From: someone@example.com<br>To: anyone@example.com</p>"
+        '<p><img src="cid:image001.jpg"><br>Quoted text</p>'
+    )
+
+    assert unwrap_html(html) == {
+        "type": "forward",
+        "from": "someone@example.com",
+        "to": "anyone@example.com",
+        "html_top": "<p>Top text</p>",
+        "html": '<p><img src="cid:image001.jpg"><br>Quoted text</p>',
+    }
+
+
 @pytest.mark.parametrize(
     ("file", "expected"),
     [

--- a/tests/test_unwrap_html.py
+++ b/tests/test_unwrap_html.py
@@ -22,6 +22,23 @@ def test_unwrap_html_simple(html, expected):
     assert unwrap_html(html) == expected
 
 
+def test_unwrap_html_image_only_quoted_body():
+    # The quoted message consists of an inline image only, with no text.
+    html = (
+        "<p>Top text</p>"
+        "<p>From: someone@example.com<br>To: anyone@example.com</p>"
+        '<p><img src="cid:image001.jpg"></p>'
+    )
+
+    assert unwrap_html(html) == {
+        "type": "forward",
+        "from": "someone@example.com",
+        "to": "anyone@example.com",
+        "html_top": "<p>Top text</p>",
+        "html": '<p><img src="cid:image001.jpg"></p>',
+    }
+
+
 @pytest.mark.parametrize(
     ("file", "expected"),
     [


### PR DESCRIPTION
Apologies if this is missing something, not sure what the contribution guidelines are.

Came across a case where people were forwarding emails that were only an image. Because the forwarded content wasn't any text, the line would get stripped out and you'd only get an `html_top` with no quoted content. Also incidentally fixes #22 

The fix I'm proposing here is to add some "text" for the image line so it isn't entirely stripped out. The choice of a [Unicode object replacement character](https://www.compart.com/en/unicode/U+FFFC) was entirely arbitrary. Happy to swap it out for any other string if preferred.