### PR TITLE
Strip XML-illegal characters from input HTML in `get_html_tree()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## Unreleased
+
+* Strip XML-illegal characters from input HTML in `get_html_tree()`. `lxml`
+  parses them into the tree but raises `ValueError: All strings must be XML
+  compatible` when any text or attribute assignment later touches them. NULL
+  bytes, previously replaced with U+FFFD by the parser are now removed.
+
 ## v0.5.1
 
 * Fixes for lxml >=6 compatibility

--- a/quotequail/_html.py
+++ b/quotequail/_html.py
@@ -11,7 +11,12 @@ if TYPE_CHECKING:
     from lxml.html import HtmlElement
 
 from ._enums import Position
-from ._patterns import FORWARD_LINE, FORWARD_STYLES, MULTIPLE_WHITESPACE_RE
+from ._patterns import (
+    FORWARD_LINE,
+    FORWARD_STYLES,
+    MULTIPLE_WHITESPACE_RE,
+    XML_ILLEGAL_CHARS_RE,
+)
 
 Element: TypeAlias = "HtmlElement"
 ElementRef = tuple["Element", Position]
@@ -215,6 +220,11 @@ def get_html_tree(html_str: str) -> Element:
     otherwise result in an error. The wrapping can be later removed with
     strip_wrapping().
     """
+    # Strip invalid XML characters. The HTML parser tolerates XML-illegal
+    # characters and preserves them into the tree... but they will raise
+    # a ValueError when they are used downstream.
+    html_str = XML_ILLEGAL_CHARS_RE.sub("", html_str)
+
     parser = lxml.html.HTMLParser(encoding="utf-8")
     htmlb = html_str.encode("utf8")
 

--- a/quotequail/_patterns.py
+++ b/quotequail/_patterns.py
@@ -118,7 +118,7 @@ MULTIPLE_WHITESPACE_RE = re.compile(r"\s+")
 
 # Characters outside the XML 1.0 Char production spec (section 2.2)
 XML_ILLEGAL_CHARS_RE: re.Pattern[str] = re.compile(
-    "[\x00-\x08\x0b\x0c\x0e-\x1f\ufffe\uffff]"
+    "[\x00-\x08\x0b\x0c\x0e-\x1f\ud800-\udfff\ufffe\uffff]"
 )
 
 # Amount to lines to join to check for potential wrapped patterns in plain text

--- a/quotequail/_patterns.py
+++ b/quotequail/_patterns.py
@@ -116,6 +116,11 @@ COMPILED_PATTERNS: list[re.Pattern] = [
 
 MULTIPLE_WHITESPACE_RE = re.compile(r"\s+")
 
+# Characters outside the XML 1.0 Char production spec (section 2.2)
+XML_ILLEGAL_CHARS_RE: re.Pattern[str] = re.compile(
+    "[\x00-\x08\x0b\x0c\x0e-\x1f\ufffe\uffff]"
+)
+
 # Amount to lines to join to check for potential wrapped patterns in plain text
 # messages.
 MAX_WRAP_LINES = 2

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -151,6 +151,8 @@ def test_get_html_tree_flattens_malformed_tags(html, expected):
         ),
         # NULL byte and noncharacters in ordinary text.
         ("<div>a\x00b\ufffec\uffff</div>", "<div>abc</div>"),
+        # Lone surrogate.
+        ("<div>a\ud800b</div>", "<div>ab</div>"),
         # Email with binary garbage found in the wild.
         (
             (

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -136,6 +136,45 @@ def test_get_html_tree_flattens_malformed_tags(html, expected):
     assert render_html_tree(get_html_tree(html)) == expected
 
 
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        # Control character next to a flattened pseudo-tag
+        (
+            "<div><foo@bar>\x01text</foo@bar></div>",
+            "<div>&lt;foo@bar&gt;text</div>",
+        ),
+        # Control character as a value
+        (
+            '<div><foo@bar baz="\x02">hi</foo@bar></div>',
+            '<div>&lt;foo@bar baz=""&gt;hi</div>',
+        ),
+        # NULL byte and noncharacters in ordinary text.
+        ("<div>a\x00b\ufffec\uffff</div>", "<div>abc</div>"),
+        # Email with binary garbage found in the wild.
+        (
+            (
+                "<div><p>hi</p><e!s\ufffd@\ufffd\ufffda "
+                ':\ufffd9\ufffd\x15\ufffdk\x1a\ufffd\x18\ufffd6="">'
+                "after</div>"
+            ),
+            (
+                "<div><p>hi</p>&lt;e!s\ufffd@\ufffd\ufffda "
+                ':\ufffd9\ufffd\ufffdk\ufffd\ufffd6=""&gt;after</div>'
+            ),
+        ),
+    ],
+)
+def test_get_html_tree_strips_xml_illegal_chars(html, expected):
+    assert render_html_tree(get_html_tree(html)) == expected
+
+
+def test_get_html_tree_keeps_xml_legal_whitespace():
+    # Control characters inside the XML 1.0 Char production and should survive.
+    tree = get_html_tree("<div>a\tb\nc</div>")
+    assert tree.xpath("string()") == "a\tb\nc"
+
+
 def test_get_html_tree_outlook_tag_roundtrip():
     # Outlook uses <o:p> for paragraph padding. The tag must survive the
     # get_html_tree → render_html_tree roundtrip unchanged.

--- a/tests/test_quote_html.py
+++ b/tests/test_quote_html.py
@@ -291,3 +291,15 @@ test ä
 </html>""",
         ),
     ]
+
+
+def test_control_character_in_quoted_block():
+    # Splitting the tree at the quote boundary reassigns parsed text through
+    # lxml's validating setters (trim_tree_before), which reject XML-illegal
+    # characters unless get_html_tree() stripped them from the input.
+    assert quote_html(
+        "<div>reply<blockquote>On foo wrote:<br>quoted\x01stuff</blockquote></div>"
+    ) == [
+        (True, "<div>reply<blockquote>On foo wrote:</blockquote></div>"),
+        (False, "<div><blockquote>quotedstuff</blockquote></div>"),
+    ]


### PR DESCRIPTION
The PR strips invalid control characters from HTML before parsing. The `lxml` HTML parser preserves control characters into the tree, but any later text or attribute assignment through the `lxml` API rejects them with `ValueError: All strings must be XML compatible`. An email combining an unescaped pseudo-tag like `<addr@domain>` with a nearby control character is currently crashing `get_html_tree()`. List of characters to strip is from the `XML 1.0 Char production` spec.