### PR TITLE
Release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes
 
-## Unreleased
+## v0.5.2
 
 * Strip XML-illegal characters from input HTML in `get_html_tree()`. `lxml`
   parses them into the tree but raises `ValueError: All strings must be XML

--- a/quotequail/__init__.py
+++ b/quotequail/__init__.py
@@ -4,7 +4,7 @@
 from . import _internal, _patterns
 from ._enums import Position
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __all__ = ["quote", "quote_html", "unwrap", "unwrap_html"]
 
 


### PR DESCRIPTION
# v0.5.2

* Strip XML-illegal characters from input HTML in `get_html_tree()`. `lxml` parses them into the tree but raises `ValueError: All strings must be XML compatible` when any text or attribute assignment later touches them. NULL bytes, previously replaced with U+FFFD by the parser are now removed.
