### PR TITLE
Flatten all invalid tags in `get_html_tree()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## Unreleased
+
+* Flatten malformed tags whose names are not valid XML 1.0 Names in
+  `get_html_tree()`. Previously only tags containing `:`, `@` or `=` were
+  flattened.
+
 ## v0.5.2
 
 * Strip XML-illegal characters from input HTML in `get_html_tree()`. `lxml`

--- a/quotequail/_html.py
+++ b/quotequail/_html.py
@@ -213,6 +213,25 @@ def slice_tree(
     return new_tree
 
 
+def _is_valid_xml_name(tag: str) -> bool:
+    """
+    Whether `tag` is a valid XML 1.0 Name (spec section 2.3,
+    https://www.w3.org/TR/REC-xml/#NT-Name), delegating the
+    character-level validation to lxml: each colon-separated part must
+    be an NCName, which is exactly what `lxml.etree.QName` checks.
+    ':' is a legal name character per the spec (reserved for
+    namespaces), so parts may be empty: 'o:p' and 'http:' are valid
+    names, 'b"x' and '1num' are not.
+    """
+    try:
+        for part in tag.split(":"):
+            if part:
+                lxml.etree.QName(part)
+    except ValueError:
+        return False
+    return True
+
+
 def get_html_tree(html_str: str) -> Element:
     """
     Given the HTML string, returns a LXML tree object. The tree is wrapped in
@@ -240,9 +259,12 @@ def get_html_tree(html_str: str) -> Element:
         htmlb = b"<div>" + htmlb + b"</div>"
         tree = lxml.html.fromstring(htmlb, parser=parser)
 
-    # HACK: `:` and `@` in tag names (Outlook's <o:p>, or unescaped
-    # <addr@domain> from a quoted reply header) crash slice_tree's XPath
-    # lookups later. Rewrite them here.
+    # HACK: lxml's HTML parser preserves tag names that break processing
+    # downstream: names that are not valid XML 1.0 Names (quotes, '@', '=',
+    # '<', ... from unescaped pseudo-tags like <addr@domain> or <b"x>) crash
+    # slice_tree's XPath lookups and lxml's tag restoration. Fix them all
+    # here, at the single parse choke point.
+    #
     for el in list(tree.iter()):
         if not isinstance(el.tag, str):
             # comments / processing instructions
@@ -254,18 +276,18 @@ def get_html_tree(html_str: str) -> Element:
             el.attrib["__tag_name"] = f"{prefix}:{el.tag}"
             el.tag = "span"
 
-        elif ":" in el.tag and not any(c in el.tag for c in ('"', "=", " ")):
-            # Outlook <o:p> padding: same treatment, round-tripped.
-            # Only applies to genuine namespace tags (e.g. o:p, v:shape).
-            # Tags that contain '"', '=', or spaces alongside ':' are garbage
-            # from malformed HTML (e.g. <ahref="https:...>) and must be
-            # flattened instead, since restoring them would raise ValueError.
+        elif ":" in el.tag and _is_valid_xml_name(el.tag):
+            # Valid ':'-containing name (Outlook's <o:p> padding): rename
+            # to <span>, restore on output. ':'-containing junk (e.g.
+            # <ahref="https:...>) fails the name check and is flattened
+            # below.
             el.attrib["__tag_name"] = el.tag
             el.tag = "span"
 
-        elif ":" in el.tag or "@" in el.tag or "=" in el.tag:
-            # Malformed tag whose name contains XPath-special or otherwise
-            # invalid characters. Flatten back to visible text.
+        elif not _is_valid_xml_name(el.tag):
+            # Malformed tag (unescaped <addr@domain>, <b"x>, ...):
+            # getelementpath() would embed its name verbatim in an XPath
+            # expression. Flatten back to visible text.
             attrs = "".join(
                 f' {k}="{html.escape(v, quote=True)}"'
                 for k, v in el.attrib.items()

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -127,12 +127,34 @@ def test_trim_before():
             "<div>x<a:b=c>click</a:b>z</div>",
             "<div>x&lt;a:b=c&gt;clickz</div>",
         ),
+        # '"' in tag name — getelementpath() embeds it verbatim in the
+        # XPath expression (XPathEvalError: Invalid expression)
+        (
+            '<div>x<b"x>y</b"x>z</div>',
+            '<div>x&lt;b"x&gt;yz</div>',
+        ),
+        # "'" in tag name — same as above
+        (
+            "<div>x<b'x>y</b'x>z</div>",
+            "<div>x&lt;b'x&gt;yz</div>",
+        ),
+        # '<' in tag name — would silently evaluate as an XPath comparison
+        # instead of matching the element
+        (
+            "<div>x<a<b>y</a<b>z</div>",
+            "<div>x&lt;a&lt;b&gt;yz</div>",
+        ),
+        # '&' in tag name
+        (
+            "<div>x<a&b>y</a&b>z</div>",
+            "<div>x&lt;a&amp;b&gt;yz</div>",
+        ),
     ],
 )
 def test_get_html_tree_flattens_malformed_tags(html, expected):
-    # Tags whose names contain XPath-special or invalid characters
-    # must be rendered as escaped visible text rather than roundtripped as real
-    # tags,which would raise ValueError in lxml
+    # Tag names that are not valid XML names must be flattened to escaped
+    # visible text instead of kept as elements: they crash slice_tree's
+    # XPath lookups and lxml's tag restoration.
     assert render_html_tree(get_html_tree(html)) == expected
 
 

--- a/tests/test_quote_html.py
+++ b/tests/test_quote_html.py
@@ -1,6 +1,6 @@
 import pytest
 
-from quotequail import quote_html
+from quotequail import quote_html, unwrap_html
 
 
 @pytest.mark.parametrize(
@@ -263,6 +263,24 @@ def test_tag_with_equals_sign():
             "</body></html>",
         ),
     ]
+
+
+def test_unwrap_html_tag_with_quote_in_name():
+    result = unwrap_html(
+        '<div"x>Hi there</div"x>'
+        "<div><br></div>"
+        "<div>On Sep 4, 2026, Foo &lt;foo@bar.com&gt; wrote:<br></div>"
+        "<blockquote><div>quoted line</div></blockquote>"
+        "<div>Regards</div>"
+    )
+    assert result == {
+        "type": "reply",
+        "html_top": '&lt;div"x&gt;Hi there',
+        "html_bottom": "<div>Regards</div>",
+        "html": "<div><div>quoted line</div></div>",
+        "date": "Sep 4, 2026",
+        "from": "Foo <foo@bar.com>",
+    }
 
 
 def test_encoding():


### PR DESCRIPTION
This PR removes the hardcoded invalid character checks (`"`, `=`, ` `) in favor an expanded check against all valid XML 1.0 Names using `lxml.etree.QName`. Anything that isn't valid is flattened.